### PR TITLE
ETCD_PEER format should be http://<server>:<port>

### DIFF
--- a/app.go
+++ b/app.go
@@ -28,7 +28,7 @@ func init() {
 
 	// init global variables
 	renderer = render.New(render.Options{})
-	fleetClient = NewClientCLIWithPeer(fmt.Sprintf("http://%s:4001", etcdPeer))
+	fleetClient = NewClientCLIWithPeer(fmt.Sprintf("%s", etcdPeer))
 	tempDir = "./tmp"
 	if _, err := os.Stat(tempDir); os.IsNotExist(err) {
 		os.Mkdir(tempDir, 0755)


### PR DESCRIPTION
When you run a Docker container should be able to specify etcd port. 
So for example: `-e ETCD_PEER=http://172.17.42.1:2379`