### PR TITLE
Use relative paths to allow deployment to sub-folder

### DIFF
--- a/angular/app/scripts/app.js
+++ b/angular/app/scripts/app.js
@@ -35,29 +35,29 @@ angular
       /* login 하기 전 */
       .state('root', {
         abstract: true,
-        templateUrl: _t('/views/layout.html')
+        templateUrl: _t('views/layout.html')
       })
         .state('root.main', {
           url: '/',
-          templateUrl: _t('/views/main.html'),
+          templateUrl: _t('views/main.html'),
           controller: 'MainCtrl'
         })
           .state('root.main.unit', {
             url: 'unit?name',
-            templateUrl: _t('/views/unit.html'),
+            templateUrl: _t('views/unit.html'),
             controller: 'UnitCtrl'
           })
           .state('root.main.new_unit', {
             url: 'unit/new',
-            templateUrl: _t('/views/new-unit.html'),
+            templateUrl: _t('views/new-unit.html'),
             controller: 'NewUnitCtrl'
           });
 
     // Plupload 설정
     /* jshint camelcase:false */
     pluploadOptionProvider.setOptions({
-      flash_swf_url: '/bower_components/plupload/js/Moxie.swf',
-      silverlight_xap_url: '/bower_components/plupload/js/Moxie.xap'
+      flash_swf_url: 'bower_components/plupload/js/Moxie.swf',
+      silverlight_xap_url: 'bower_components/plupload/js/Moxie.xap'
     });
   })
   .run(function($rootScope, $state, $stateParams) {

--- a/angular/app/scripts/controllers/new-unit.js
+++ b/angular/app/scripts/controllers/new-unit.js
@@ -36,7 +36,7 @@ angular.module('fleetuiApp')
 
     $scope.unitUpload = {
       loading: false,
-      url: '/api/v1/units/upload',
+      url: 'api/v1/units/upload',
       options: {
         container: 'unitUploadBtn',
         multi_selection: false,

--- a/angular/app/scripts/controllers/unit.js
+++ b/angular/app/scripts/controllers/unit.js
@@ -101,11 +101,11 @@ angular.module('fleetuiApp')
     if($location.protocol() == 'https') {
       wsprotocol = 'wss://'
     }
-    
+
     if(ENVIRONMENT == 'dev') {
-      WebSocket.new(wsprotocol + $location.host() + ':3000' + '/ws/journal/' + unitName);
+      WebSocket.new(wsprotocol + $location.host() + ':3000' + window.location.pathname + 'ws/journal/' + unitName);
     } else {
-      WebSocket.new(wsprotocol + $location.host() + ':' + $location.port() + '/ws/journal/' + unitName);
+      WebSocket.new(wsprotocol + $location.host() + ':' + $location.port() + window.location.pathname + 'ws/journal/' + unitName);
     }
     setCallback();
     $scope.$on('$destroy', function () {

--- a/angular/app/scripts/services/machine-service.js
+++ b/angular/app/scripts/services/machine-service.js
@@ -9,7 +9,7 @@
  */
 angular.module('fleetuiApp')
   .service('machineService', function machineService($resource) {
-    return $resource('/api/v1/machines/:collection_action/:id/:member_action', {
+    return $resource('api/v1/machines/:collection_action/:id/:member_action', {
       id: '@id'
     });
   });

--- a/angular/app/scripts/services/unit-service.js
+++ b/angular/app/scripts/services/unit-service.js
@@ -9,7 +9,7 @@
  */
 angular.module('fleetuiApp')
   .service('unitService', function unitService($resource) {
-    return $resource('/api/v1/units/:collection_action/:id/:member_action', {
+    return $resource('api/v1/units/:collection_action/:id/:member_action', {
       id: '@id'
     }, {
       start: {


### PR DESCRIPTION
With these changes, it's possible to deploy fleet-ui under a sub-folder, like this: https://domain.tld/fleet-ui

I also noticed that the font-awesome fonts are not copied under dist/ when building, but it's not in the scope of this PR, so I didn't fix it.
