### PR TITLE
Fix Websocket hijacking vulnerability

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -193,6 +193,13 @@ var upgrader = websocket.Upgrader{
 }
 
 func wsHandler(w http.ResponseWriter, r *http.Request) {
+	upgrader.CheckOrigin = func(r *http.Request) bool {
+		if (r.Header.Get("Origin") == "http://" + r.Host) || (r.Header.Get("Origin") == "https://" + r.Host) {
+			return true
+		}
+		http.Error(w, "websocket: request origin not allowed by Upgrader.CheckOrigin", http.StatusForbidden)
+		return false
+	}
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
WebSockets don't follow the Same-Origin Policy. This means that if the application relies on cookies (or Basic authentication) to perform authentication/authorization, a malicious website can get a victim to access this application via a WebSocket and potentially access/modify sensitive data as this user.

I created a Proof of Concept (malicious html-page) allowing read logs through this vulnerability.

More information about the vulnerability you can find here:
https://portswigger.net/web-security/websockets/cross-site-websocket-hijacking

To prevent this issue, the Origin header check was added.



